### PR TITLE
bacon: camera: Restore 1280x960 front preview resolution

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -387,7 +387,7 @@ static char *camera_get_parameters(struct camera_device *device)
         params.set(CameraParameters::KEY_SUPPORTED_VIDEO_SIZES,
             "1280x720,864x480,800x480,720x480,640x480,320x240,176x144");
         params.set(CameraParameters::KEY_SUPPORTED_PREVIEW_SIZES,
-            "1280x720,720x480,640x480,576x432,320x240");
+            "1280x960,1280x720,720x480,640x480,576x432,320x240");
         params.set("preview-fps-range-values", "(7500,30000),(8000,30000),(30000,30000)");
         if(strcmp(params.get(CameraParameters::KEY_PICTURE_SIZE), "352x288") == 0 ||
            strcmp(params.get(CameraParameters::KEY_PICTURE_SIZE), "176x144") == 0) {


### PR DESCRIPTION
The removal of 1280x960 4:3 aspect ratio preview resolution
for the front camera is causing a similar issue as missing
1440x1080 on the rear camera. It also causes issues such as
hangouts video being visually stretched.

OPO-413

Change-Id: Idebac1097db2f89ecf0648848479e23040b6012b
