### PR TITLE
bacon: Don't use QC location stack

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -192,15 +192,6 @@
     <bool name="use_motion_accel">false</bool>
     -->
 
-    <!-- Enable overlay for all location components. -->
-    <bool name="config_enableNetworkLocationOverlay" translatable="false">false</bool>
-    <string name="config_networkLocationProviderPackageName" translatable="false">com.qualcomm.location</string>
-    <bool name="config_enableFusedLocationOverlay" translatable="false">false</bool>
-    <string name="config_fusedLocationProviderPackageName" translatable="false">com.qualcomm.location</string>
-
-    <!-- Component name of the combo network location provider. -->
-    <string name="config_comboNetworkLocationProvider" translatable="false">com.qualcomm.location</string>
-
     <!-- Device specific options -->
 
     <!-- Default LED on time for notification LED in milliseconds. -->


### PR DESCRIPTION
- The QC fused provider still has serious issues with location
  injection, which leads to it being unable to hold a fine location.
- Use the Google fused/network provider instead.

OPO-462
Change-Id: I9c7a5bf0c62cdcb4c38827352fa0d5e40480e63a
