### PR TITLE
bacon: Completely remove QC location stack

### DIFF
--- a/proprietary-files-qc.txt
+++ b/proprietary-files-qc.txt
@@ -36,24 +36,15 @@ vendor/lib/drm/libdrmwvmplugin.so
 #vendor/lib/mediadrm/libwvdrmengine.so
 
 # GPS
--priv-app/com.qualcomm.location/com.qualcomm.location.apk
 bin/loc_launcher
-etc/permissions/com.qualcomm.location.xml
 lib/libloc_api_v02.so
 lib/libloc_ds_api.so
 vendor/lib/hw/activity_recognition.msm8974.so
 vendor/lib/hw/flp.default.so
-vendor/lib/libalarmservice_jni.so
-vendor/lib/libdataitems.so
 vendor/lib/libflp.so
 vendor/lib/libgeofence.so
 vendor/lib/libizat_core.so
 vendor/lib/liblbs_core.so
-vendor/lib/liblocationservice.so
-vendor/lib/liblocationservice_glue.so
-vendor/lib/liblowi_client.so
-vendor/lib/libxtwifi_ulp_adaptor.so
-vendor/lib/libulp2.so
 
 # Graphics
 vendor/lib/egl/eglsubAndroid.so

--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -98,7 +98,6 @@ done
 DEVICE_PACKAGE_OVERLAYS += vendor/$VENDOR/$DEVICE/overlay
 
 PRODUCT_PACKAGES += \\
-    com.qualcomm.location \\
     qcrilmsgtunnel \\
     shutdownlistener
 
@@ -167,17 +166,6 @@ LOCAL_PATH := \$(call my-dir)
 ifneq (\$(filter bacon,\$(TARGET_DEVICE)),)
 
 ifeq (\$(QCPATH),)
-
-include \$(CLEAR_VARS)
-LOCAL_MODULE := com.qualcomm.location
-LOCAL_MODULE_OWNER := $VENDOR
-LOCAL_SRC_FILES := proprietary/priv-app/com.qualcomm.location/com.qualcomm.location.apk
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_SUFFIX := \$(COMMON_ANDROID_PACKAGE_SUFFIX)
-LOCAL_MODULE_CLASS := APPS
-LOCAL_CERTIFICATE := platform
-LOCAL_PRIVILEGED_MODULE := true
-include \$(BUILD_PREBUILT)
 
 include \$(CLEAR_VARS)
 LOCAL_MODULE := qcrilmsgtunnel


### PR DESCRIPTION
- liblbs_core checks for existence of com.qualcomm.location to determine
  whether location injection occurs.

REF: CYNGNOS-1514 OPO-462
Change-Id: I2be7b08814dd641100dfc94ef7b6ae98a127ba62
