### PR TITLE
bacon: camera: Workarounds for google camera crash

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -420,6 +420,11 @@ static char *camera_get_parameters(struct camera_device *device)
     params.set("clear-image-values", "off,on");
     params.set("clear-image", gClearImageEnabled ? "on" : "off");
 
+    const char *pf = params.get(android::CameraParameters::KEY_PREVIEW_FORMAT);
+    if (pf && strcmp(pf, "nv12-venus") == 0) {
+        params.set(android::CameraParameters::KEY_PREVIEW_FORMAT, "yuv420sp");
+    }
+
     params.remove("high-resolution");
     params.remove("superzoom");
 


### PR DESCRIPTION
Google camera crash after a 4k video is recorded and
switch back to camera (photo) module.
The reason is that there is a hack in camera hal,
forcing the 4k recording preview-format to be nv12-venus.
When switch back to camera module, get parameter still
return pixel format nv12-venus which trigger the following
exceptions:

CAM2PORT_AndCamAgntImp: RuntimeException during CameraAction[APPLY_SETTINGS] at CameraState[2]
CAM2PORT_AndCamAgntImp: java.lang.IllegalArgumentException: Invalid pixel_format=0
CAM2PORT_AndCamAgntImp:        at android.hardware.Camera$Parameters.setPreviewFormat(Camera.java:3220)
CAM2PORT_AndCamAgntImp:        at com.android.ex.camera2.portability.AndroidCameraAgentImpl$CameraHandler.applySettingsToParameters(AndroidCameraAgentImpl.java:667)
CAM2PORT_AndCamAgntImp:        at com.android.ex.camera2.portability.AndroidCameraAgentImpl$CameraHandler.handleMessage(AndroidCameraAgentImpl.java:566)
CAM2PORT_AndCamAgntImp:        at android.os.Handler.dispatchMessage(Handler.java:102)
CAM2PORT_AndCamAgntImp:        at android.os.Looper.loop(Looper.java:148)
CAM2PORT_AndCamAgntImp:        at android.os.HandlerThread.run(HandlerThread.java:61)
CAM2PORT_AndCamAgntImp: Release camera since mCamera is not null.

OPO-611

Change-Id: Iaaa0fd02e770ee611a358882ae184da96b12bf2c
